### PR TITLE
Add contribution guidelines, setup instructions, and license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to smida
+
+Thank you for considering contributing to **smida**! We welcome issues and pull
+requests that improve the project.
+
+## How to Contribute
+
+1. Fork this repository and create your feature branch from `main`.
+2. Make your changes with clear and concise commits.
+3. If the project contains tests, run them locally before submitting your PR.
+4. Open a pull request describing your changes.
+5. Participate in the review process and address any feedback.
+
+Please ensure that all contributions comply with the [MIT license](LICENSE).
+
+## Development Setup
+
+The project can be developed locally using Docker. Ensure you have Docker
+installed and running on your machine.
+
+```bash
+# Clone the repository
+git clone https://github.com/your-username/smida.git
+cd smida
+
+# Build the Docker image
+docker build -t smida .
+
+# Start the application (adjust the port as needed)
+docker run --rm -it -p 8000:8000 smida
+```
+
+### Running Tests
+
+If test suites are available, they can be executed inside the container:
+
+```bash
+# Example: running tests
+docker run --rm smida npm test
+```
+
+### Deployment
+
+A CI/CD pipeline can be used to deploy the site automatically. A typical
+workflow with GitHub Actions might include the following steps:
+
+1. Build the Docker image on every push.
+2. Run any tests to verify the build.
+3. Push the image to a registry and deploy it to your hosting provider.
+
+Feel free to adapt the pipeline to fit your hosting environment.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 smida
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # smida
+
 思密达社区
+
+smida（思密达）是一个社区项目。
+
+## Development Setup
+
+This project can be run locally using Docker:
+
+```bash
+# Build the Docker image
+docker build -t smida .
+
+# Start the application
+docker run --rm -it -p 8000:8000 smida
+```
+
+If tests are available, run them within the container:
+
+```bash
+# Example: running tests
+docker run --rm smida npm test
+```
+
+For automated deployment, a CI/CD pipeline (for example using GitHub Actions)
+can build the Docker image, run tests, and deploy the container to your hosting
+provider.
+
+## Contributing
+
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to get
+started with development and submit pull requests.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- add `CONTRIBUTING.md` describing how to contribute and how to use Docker for local setup, testing, and deployment via CI/CD
- include an MIT `LICENSE` file for usage rights
- update `README.md` with setup, contribution link, and license section

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6841b208a31c8324b0f8d495152f3f80