### PR TITLE
Add Flask-based activity and payment API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # smida
-思密达社区
+
+A simple Flask-based community API with activities and payments.
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install Flask Flask-SQLAlchemy
+```
+
+Run the application:
+
+```bash
+python -m smidapi.app
+```
+
+## API Endpoints
+
+- `POST /register` – register new user and receive auth token.
+- `POST /activities` – create activity (requires `Authorization` header).
+- `GET /activities` – list activities.
+- `POST /activities/<id>/pay` – pay for an activity using Alipay, WeChat Pay or KakaoPay.

--- a/smidapi/__init__.py
+++ b/smidapi/__init__.py
@@ -1,0 +1,1 @@
+from .app import create_app

--- a/smidapi/app.py
+++ b/smidapi/app.py
@@ -1,0 +1,84 @@
+from flask import Flask, request, jsonify, abort
+from uuid import uuid4
+
+from .config import Config
+from .models import db, User, Activity, Payment, Post
+from .payments import PaymentGateway
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config.from_object(Config)
+    db.init_app(app)
+
+    payment_gateway = PaymentGateway()
+
+    def require_auth(f):
+        def wrapper(*args, **kwargs):
+            token = request.headers.get('Authorization')
+            if not token:
+                abort(401)
+            user = User.query.filter_by(token=token).first()
+            if not user:
+                abort(401)
+            return f(user, *args, **kwargs)
+        wrapper.__name__ = f.__name__
+        return wrapper
+
+    @app.before_first_request
+    def create_tables():
+        db.create_all()
+
+    @app.route('/register', methods=['POST'])
+    def register():
+        data = request.json
+        username = data.get('username')
+        password = data.get('password')
+        if not username or not password:
+            return jsonify({'error': 'username and password required'}), 400
+        if User.query.filter_by(username=username).first():
+            return jsonify({'error': 'username exists'}), 400
+        token = str(uuid4())
+        user = User(username=username, password=password, token=token)
+        db.session.add(user)
+        db.session.commit()
+        return jsonify({'token': token})
+
+    @app.route('/activities', methods=['POST'])
+    @require_auth
+    def create_activity(user):
+        data = request.json
+        title = data.get('title')
+        description = data.get('description')
+        activity = Activity(title=title, description=description, creator_id=user.id)
+        db.session.add(activity)
+        db.session.commit()
+        return jsonify({'id': activity.id, 'title': activity.title})
+
+    @app.route('/activities', methods=['GET'])
+    def list_activities():
+        activities = Activity.query.all()
+        return jsonify([
+            {'id': a.id, 'title': a.title, 'description': a.description, 'date': a.date.isoformat()}
+            for a in activities
+        ])
+
+    @app.route('/activities/<int:activity_id>/pay', methods=['POST'])
+    @require_auth
+    def pay(user, activity_id):
+        data = request.json
+        amount = data.get('amount')
+        provider = data.get('provider')
+        activity = Activity.query.get_or_404(activity_id)
+        result = payment_gateway.pay(provider, amount)
+        payment = Payment(user_id=user.id, activity_id=activity.id, amount=amount,
+                          status=result['status'], provider=provider)
+        db.session.add(payment)
+        db.session.commit()
+        return jsonify(result)
+
+    return app
+
+if __name__ == '__main__':
+    app = create_app()
+    app.run(debug=True)

--- a/smidapi/config.py
+++ b/smidapi/config.py
@@ -1,0 +1,6 @@
+import os
+
+class Config:
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'devkey')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'sqlite:///smida.db')
+    SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/smidapi/models.py
+++ b/smidapi/models.py
@@ -1,0 +1,39 @@
+from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime
+
+# initialize SQLAlchemy without app, will be initialized later
+
+db = SQLAlchemy()
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password = db.Column(db.String(128), nullable=False)
+    token = db.Column(db.String(36), unique=True)
+
+    def __repr__(self):
+        return f'<User {self.username}>'
+
+class Activity(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(120), nullable=False)
+    description = db.Column(db.Text)
+    date = db.Column(db.DateTime, default=datetime.utcnow)
+    creator_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+
+    def __repr__(self):
+        return f'<Activity {self.title}>'
+
+class Payment(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    activity_id = db.Column(db.Integer, db.ForeignKey('activity.id'))
+    amount = db.Column(db.Float, nullable=False)
+    status = db.Column(db.String(20), default='pending')
+    provider = db.Column(db.String(50))
+
+class Post(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    content = db.Column(db.Text, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)

--- a/smidapi/payments.py
+++ b/smidapi/payments.py
@@ -1,0 +1,21 @@
+class PaymentGateway:
+    def pay(self, provider, amount, **kwargs):
+        if provider == 'alipay':
+            return self._alipay(amount, **kwargs)
+        if provider == 'wechat':
+            return self._wechat(amount, **kwargs)
+        if provider == 'kakaopay':
+            return self._kakaopay(amount, **kwargs)
+        raise ValueError('Unsupported provider')
+
+    def _alipay(self, amount, **kwargs):
+        # integrate with Alipay SDK here
+        return {'provider': 'alipay', 'amount': amount, 'status': 'success'}
+
+    def _wechat(self, amount, **kwargs):
+        # integrate with WeChat Pay SDK here
+        return {'provider': 'wechat', 'amount': amount, 'status': 'success'}
+
+    def _kakaopay(self, amount, **kwargs):
+        # integrate with KakaoPay SDK here
+        return {'provider': 'kakaopay', 'amount': amount, 'status': 'success'}


### PR DESCRIPTION
## Summary
- create Flask app with registration, activities, and payment APIs
- define SQLAlchemy models for users, activities, payments, and community posts
- provide simple payment gateway stubs for Alipay, WeChat Pay and KakaoPay
- update README with setup instructions and API endpoints

## Testing
- `python -m smidapi.app --help` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6841b202bc208324b405bb340fd624e2